### PR TITLE
Fix batch response return

### DIFF
--- a/geocode_test.go
+++ b/geocode_test.go
@@ -307,14 +307,22 @@ func TestGeocodeInvalidNoResults(t *testing.T) {
 	if err != geocodio.ErrNoResultsFound {
 		t.Error("Expected error", geocodio.ErrNoResultsFound.Error(), "but saw", err.Error())
 	}
+}
 
-	resp, err = gc.GeocodeBatch("123 Nonsense Ln, Nowhere, XX")
-	if err == nil {
-		t.Error("Expected to see an error")
-		fmt.Println(resp.ResponseAsString())
-		return
+func TestGeocodeBatchInvalidNoResults(t *testing.T) {
+	gc, err := geocodio.New()
+	if err != nil {
+		t.Error("Failed with API KEY set.", err)
 	}
 
+	resp, err := gc.GeocodeBatch("123 Nonsense Ln, Nowhere, XX")
+	if err != nil {
+		t.Error("Expected success", err)
+	}
+	if resp.Results[0].Response.Error == "" {
+		t.Error("Expected to see an error")
+		fmt.Println(resp.ResponseAsString())
+	}
 }
 
 // TODO: School District (school)

--- a/reverse.go
+++ b/reverse.go
@@ -19,9 +19,10 @@ func (g *Geocodio) Reverse(latitude, longitude float64) (GeocodeResult, error) {
 	latStr := strconv.FormatFloat(latitude, 'f', 9, 64)
 	lngStr := strconv.FormatFloat(longitude, 'f', 9, 64)
 
-	resp, err := g.get("/reverse", map[string]string{"q": latStr + "," + lngStr})
+	resp := GeocodeResult{}
+	err := g.get("/reverse", map[string]string{"q": latStr + "," + lngStr}, &resp)
 	if err != nil {
-		return GeocodeResult{}, err
+		return resp, err
 	}
 
 	if len(resp.Results) == 0 {
@@ -44,13 +45,14 @@ func (g *Geocodio) ReverseGeocode(latitude, longitude float64) (GeocodeResult, e
 }
 
 // ReverseBatch supports a batch lookup by lat/lng coordinate pairs
-func (g *Geocodio) ReverseBatch(latlngs ...float64) (GeocodeResult, error) {
+func (g *Geocodio) ReverseBatch(latlngs ...float64) (BatchResponse, error) {
+	resp := BatchResponse{}
 	if len(latlngs) == 0 {
-		return GeocodeResult{}, ErrReverseBatchMissingCoords
+		return resp, ErrReverseBatchMissingCoords
 	}
 
 	if len(latlngs)%2 == 1 {
-		return GeocodeResult{}, ErrReverseBatchInvalidCoordsPairs
+		return resp, ErrReverseBatchInvalidCoordsPairs
 	}
 
 	var (
@@ -72,9 +74,9 @@ func (g *Geocodio) ReverseBatch(latlngs ...float64) (GeocodeResult, error) {
 		pair = coord
 	}
 
-	resp, err := g.post("/reverse", payload, nil)
+	err := g.post("/reverse", payload, nil, &resp)
 	if err != nil {
-		return GeocodeResult{}, err
+		return resp, err
 	}
 
 	if len(resp.Results) == 0 {


### PR DESCRIPTION
This PR corrects the Batch response so that it'll work correctly. While the top-level fields are both named `results` in the batch or single-address call, they aren't the same data. This PR adds new structs to make it work correctly for a batch while retaining the capability for single-address calls. 

This adds:
1. New `BatchResponse`, `BatchResult` and `BatchResultItem` structs to capture the batch information from the top-level down to the results. Once we get to the results, the data is the same as the `Address` struct.
2. Updates all the HTTP methods to allow for a struct to be passed in for JSON Unmarshalling rather than hard-coding the struct used
3. Introduces a new `saver` interface so that debug information can be saved whether the struct passed in is a batch or single address request.


From their API reference, the single response is like this:

```
{
  "input": {
    "address_components": {...}
    "formatted_address": "1109 N Highland St, Arlington, VA 22201"
  },
  "results": [
    {
      "address_components": {...}
      "formatted_address": "1109 N Highland St, Arlington, VA 22201",
      "location": {...}
      "accuracy": 1,
      "accuracy_type": "rooftop",
      "source": "Virginia GIS Clearinghouse"
    }
  ]
}
```

The Batch response is like this. Notice the batch version has two levels of results. Also, notice the batch version includes the query used for each of the inputs.

```
{
  "results": [
    {
      "query": "1109 N Highland St, Arlington VA",
      "response": {
        "input": {
          "address_components": {...},
          "formatted_address": "1109 N Highland St, Arlington, VA"
        },
        "results": [
          {
            "address_components": {...},
            "formatted_address": "1109 N Highland St, Arlington, VA 22201",
            "location": {...},
            "accuracy": 1,
            "accuracy_type": "rooftop",
            "source": "Arlington"
          },
        ]
      }
    },
    ...
  ]
}
```